### PR TITLE
Add parameter serviceUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ LaTeX online compiler. More info at www.github.com/kpym/lol.
 
 Available options:
   -s, --service string    Service can be laton or ytotex.
+  --url        string    The base url for the service. If empty, the default URL is used.
   -c, --compiler string   One of pdflatex,xelatex or lualatex.
                           For ytotex platex, uplatex and context are also available.
                            (default "pdflatex")

--- a/app/app.go
+++ b/app/app.go
@@ -50,6 +50,7 @@ func Help() {
 // InitFlag define the CLI flags.
 func InitFlags() {
 	pflag.StringP("service", "s", "", "Service can be laton or ytotex.")
+	pflag.String("url", "", "The base url for the service. If empty, the default URL is used.")
 	pflag.StringP("compiler", "c", "pdflatex", "One of pdflatex,xelatex or lualatex.\nFor ytotex platex, uplatex and context are also available.\n")
 	pflag.BoolP("force", "f", false, "Do not use the laton cache. Force compile. Ignored by ytotech.")
 	pflag.StringP("biblio", "b", "", "Can be bibtex or biber for ytotex. Not used by laton.")
@@ -150,6 +151,14 @@ func GetParameters(params *builder.Parameters) error {
 	if params.Service == "" {
 		// TODO : choose the fastest ?
 		params.Service = "laton"
+	}
+	if params.Url == "" {
+		switch params.Service {
+		case "laton":
+			params.Url = "https://texlive2020.latexonline.cc"
+		case "ytotech":
+			params.Url = "https://latex.ytotech.com"
+		}
 	}
 	// check if the input is piped
 	fi, err := os.Stdin.Stat()

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -33,6 +33,7 @@ func (files *Files) String() string {
 type Parameters struct {
 	Log       log.Logger
 	Service   string
+	Url       string
 	Compiler  string
 	Force     bool
 	Biblio    string
@@ -46,6 +47,7 @@ type Parameters struct {
 func (p *Parameters) String() string {
 	w := new(strings.Builder)
 	fmt.Fprintln(w, "Service:  ", p.Service)
+	fmt.Fprintln(w, "Url:  ", p.Url)
 	fmt.Fprintln(w, "Compiler: ", p.Compiler)
 	if p.Force {
 		fmt.Fprintln(w, "Force:    ", p.Force)

--- a/builder/laton/laton.go
+++ b/builder/laton/laton.go
@@ -95,7 +95,7 @@ func newTarRequest(params builder.Parameters, tardata []byte) (*http.Request, er
 	urlParams.Add("command", params.Compiler)
 
 	// return the request
-	httpReq, err := http.NewRequest("POST", "https://texlive2020.latexonline.cc/data?"+urlParams.Encode(), body)
+	httpReq, err := http.NewRequest("POST", params.Url+"/data?"+urlParams.Encode(), body)
 	if err != nil {
 		return nil, err
 	}

--- a/builder/ytotech/ytotech.go
+++ b/builder/ytotech/ytotech.go
@@ -1,19 +1,21 @@
 // ytotech package provides a builder.Builder interface to latex.ytotech.com service.
 // The request send to latex.ytotech.com is a single json that looks like this
 // ```json
-// {
-//     "compiler": "pdflatex",
-//     "resources": [
-//         {
-//             "main": true,
-//             "file": "...base64 encoded file..."
-//         },
-//         {
-//             "path": "logo.png",
-//             "file": "...base64 encoded file..."
-//         }
-//     ]
-// }
+//
+//	{
+//	    "compiler": "pdflatex",
+//	    "resources": [
+//	        {
+//	            "main": true,
+//	            "file": "...base64 encoded file..."
+//	        },
+//	        {
+//	            "path": "logo.png",
+//	            "file": "...base64 encoded file..."
+//	        }
+//	    ]
+//	}
+//
 // ```
 package ytotech
 
@@ -77,7 +79,7 @@ func (y *ytotech) BuildPDF(req builder.Request) ([]byte, error) {
 	// prepare the json to submit
 	body := strings.NewReader(reqToJson(req))
 	// send comile request
-	resp, err := http.Post("https://latex.ytotech.com/builds/sync", "application/json", body)
+	resp, err := http.Post(req.Parameters.Url+"/builds/sync", "application/json", body)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
I added a parameter serviceUrl, for letting configure the service base URL.
This is useful when you're developing or when you host you're on version of the compiler services.

The default behavior is still the same.